### PR TITLE
Added name + desc text for minigun stance exit skill and inflictor for minigun stance secondary skill

### DIFF
--- a/EnforcerMod_VS/Modules/Tokens.cs
+++ b/EnforcerMod_VS/Modules/Tokens.cs
@@ -309,7 +309,8 @@ namespace Modules {
             LanguageAPI.Add("NEMFORCER_SPECIAL_MINIGUNUP_NAME", "Suppression Stance");
             LanguageAPI.Add("NEMFORCER_SPECIAL_MINIGUNUP_DESCRIPTION", "Take an offensive stance, <style=cIsDamage>readying your minigun</style>. <style=cIsHealth>Prevents sprinting</style>.");
 
-
+            LanguageAPI.Add("NEMFORCER_SPECIAL_MINIGUNDOWN_NAME", "Endurance Stance");
+            LanguageAPI.Add("NEMFORCER_SPECIAL_MINIGUNDOWN_DESCRIPTION", "Take a neutral stance, <style=cIsUtility>un-readying your minigun</style>.");
             #endregion Special
 
             #endregion SKills

--- a/EnforcerMod_VS/States/Nemforcer/Secondary/NemSecondaryMinigun.cs
+++ b/EnforcerMod_VS/States/Nemforcer/Secondary/NemSecondaryMinigun.cs
@@ -138,6 +138,7 @@ namespace EntityStates.Nemforcer {
                     blastAttack.procCoefficient = HammerSlam.procCoefficient;
                     blastAttack.position = center;
                     blastAttack.attacker = base.gameObject;
+                    blastAttack.inflictor = base.gameObject;
                     blastAttack.crit = Util.CheckRoll(base.characterBody.crit, base.characterBody.master);
                     blastAttack.baseDamage = base.characterBody.damage * HammerSlam.damageCoefficient;
                     blastAttack.falloffModel = BlastAttack.FalloffModel.None;

--- a/Release/plugins/Language/english/Nemforcer.txt
+++ b/Release/plugins/Language/english/Nemforcer.txt
@@ -36,6 +36,8 @@
     "NEMFORCER_UTILITY_CRASH_DESCRIPTION" : "<style=cIsUtility>Grappling.</style> Jump into the air, then slam down for <style=cIsDamage>2400% damage</style>. <style=cIsUtility>Deals reduced damage outside the center of the impact.</style>",
     "NEMFORCER_SPECIAL_MINIGUNUP_NAME" : "Suppression Stance",
     "NEMFORCER_SPECIAL_MINIGUNUP_DESCRIPTION" : "Take an offensive stance, <style=cIsDamage>readying your minigun</style>. <style=cIsHealth>Prevents sprinting</style>.",
+    "NEMFORCER_SPECIAL_MINIGUNDOWN_NAME" : "Endurance Stance",
+    "NEMFORCER_SPECIAL_MINIGUNDOWN_DESCRIPTION" : "Take a neutral stance, <style=cIsUtility>un-readying your minigun</style>.",
     "NEMFORCERBODY_DEFAULT_SKIN_NAME" : "Nemesis",
     "NEMFORCERBODY_ENFORCER_SKIN_NAME" : "Enforcer",
     "NEMFORCERBODY_CLASSIC_SKIN_NAME" : "Classic",


### PR DESCRIPTION
added `.inflictor` to nemforcer's secondary in the mingun stance since every other attack he has sets him as the inflictor and i only noticed the minigun stance secondary not setting it while working on a mod of mine

the minigun stance exit skill also had no actual name & description so i added them for english